### PR TITLE
Don’t enforce %i notation for arrays of Symbols

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -42,6 +42,9 @@ Style/NumericLiterals:
 Style/PercentLiteralDelimiters:
   Enabled: false
 
+Style/SymbolArray:
+  Enabled: false
+
 ############################## ENABLED ##############################
 
 Metrics/LineLength:


### PR DESCRIPTION
Since we’ve now decided to tackle time-wasting / useless cops one at a time
(see [this comment][1] on #3), here’s one I find particularly useless.

https://github.com/bbatsov/ruby-style-guide#percent-i

↑ as long as it’s readable, it doesn’t really matter whether you do `[:this]`
or `%i[that]` – not enough to have CodeClimate complain about it IMO.

[1]: https://github.com/dawanda/rubocop-config/issues/3#issuecomment-365275748