### PR TITLE
Don’t enforce %w[square brackets] for percent literals

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -39,6 +39,9 @@ Style/Lambda:
 Style/NumericLiterals:
   Enabled: false
 
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
 ############################## ENABLED ##############################
 
 Metrics/LineLength:


### PR DESCRIPTION
As previously discussed [here](https://github.com/dawanda/loveos-backend/issues/2014) and [there](https://github.com/dawanda/rubocop-config/issues/3#issuecomment-363805682)

Let’s treat each other like grown-ups: the difference between
`%w(this style)` and `%w[that style]` does not make or break readability,
but the cop does waste our time on every commit.