### PR TITLE
Allow longer blocks in RSpec

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -44,6 +44,10 @@ Style/NumericLiterals:
 Metrics/LineLength:
   Max: 120
 
+Metrics/BlockLength:
+  Exclude:
+    - '**/*_spec.rb'
+
 Metrics/MethodLength:
   Max: 20 # It would be better to have it set to 10 according to our style guide, but for now 20 will do...
 


### PR DESCRIPTION
For implementation files, a max block length of 25 NCLOC might be a sensible
(albeit arbitrary) limit, but in RSpec a `describe` block can easily grow to
more than that and it’s an impossible standard if you want to write thorough
unit tests.